### PR TITLE
fix(acme-dns-pdns): Don't overwrite pdns.conf group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,6 @@
     dest: /etc/powerdns/pdns.conf
     mode: 0640
     owner: root
-    group: root
   notify: Restart PowerDNS
 
 - name: Create PowerDNS override directory


### PR DESCRIPTION
This change is needed in order to not conflict with our acme-dns-pdns role.