### PR TITLE
Fix Debian 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ pdns is automatically restarted after configuration changes, unless the role var
 
 ## Requirements
 
-Debian or Ubuntu
+Debian 11 (Bullseye)
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,12 +8,9 @@ galaxy_info:
   min_ansible_version: 2.4
 
   platforms:
-  - name: Ubuntu
-    versions:
-    - xenial
   - name: Debian
     versions:
-    - stretch
+    - bullseye
 
 
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
     src: pdns.conf.j2
     dest: /etc/powerdns/pdns.conf
     mode: 0640
-    owner: root
+    owner: pdns
   notify: Restart PowerDNS
 
 - name: Create PowerDNS override directory


### PR DESCRIPTION
In Debian 11 the pdns.service is run by user `pdns`.